### PR TITLE
updated https.proxy link

### DIFF
--- a/_episodes/07-github.md
+++ b/_episodes/07-github.md
@@ -149,7 +149,7 @@ Branch master set up to track remote branch master from origin.
 >
 > ~~~
 > $ git config --global http.proxy http://user:password@proxy.url
-> $ git config --global https.proxy http://user:password@proxy.url
+> $ git config --global https.proxy https://user:password@proxy.url
 > ~~~
 > {: .language-bash}
 >


### PR DESCRIPTION
https.proxy link is missing an "s" in the link.